### PR TITLE
Compatibility with Rails 5.1

### DIFF
--- a/lib/active_admin/reorderable/dsl.rb
+++ b/lib/active_admin/reorderable/dsl.rb
@@ -6,7 +6,7 @@ module ActiveAdmin
       def reorderable(&block)
         body = proc do
           resource.insert_at(params[:position].to_i)
-          render :nothing => true
+          head :ok
         end
 
         member_action(:reorder, :method => :post, &block || body)


### PR DESCRIPTION
`:nothing` option for render is deprecated and will be removed in Rails 5.1. Use `head` method to respond with empty response body.