### PR TITLE
Fix reorder URL when ActiveAdmin namespace is root

### DIFF
--- a/lib/active_admin/reorderable/table_methods.rb
+++ b/lib/active_admin/reorderable/table_methods.rb
@@ -11,7 +11,8 @@ module ActiveAdmin
       private
 
       def reorder_handle_for(resource)
-        url = url_for([:reorder, active_admin_namespace.name, resource])
+        namespace = active_admin_namespace.name
+        url = namespace == :root ? url_for([:reorder, resource]) : url_for([:reorder, namespace, resource])
         span(reorder_handle_content, :class => 'reorder-handle', 'data-reorder-url' => url)
       end
 


### PR DESCRIPTION
When you have an ActiveAdmin config with:

```
config.namespace false do |admin|
  # ...
end
```

The reorder URL generation will raise an error, given there's no actual namespace being used.