### PR TITLE
Fix URL builder for reorder route

### DIFF
--- a/lib/active_admin/reorderable/table_methods.rb
+++ b/lib/active_admin/reorderable/table_methods.rb
@@ -11,7 +11,7 @@ module ActiveAdmin
       private
 
       def reorder_handle_for(resource)
-        url = url_for([:reorder, active_admin_namespace.name, resource])
+        url = [active_admin_config.route_instance_path(resource), :reorder].join('/')
         span(reorder_handle_content, :class => 'reorder-handle', 'data-reorder-url' => url)
       end
 


### PR DESCRIPTION
Preference is to use ActiveAdmin's built-in route builder so we get the correct namespace and model naming.

Tested with ActiveAdmin 1.0.0.pre.  Appears to work with current version as well.