### PR TITLE
Fix routes for nested resources

### DIFF
--- a/lib/active_admin/reorderable/table_methods.rb
+++ b/lib/active_admin/reorderable/table_methods.rb
@@ -12,9 +12,7 @@ module ActiveAdmin
 
       def reorder_handle_for(resource)
         aa_resource   = active_admin_namespace.resource_for(resource.class)
-        instance_name = aa_resource.resources_configuration[:self][:route_instance_name]
-
-        url = send([:reorder, aa_resource.route_prefix, instance_name, :path].join('_'), resource)
+        url = aa_resource.route_builder.member_action_path(:reorder, resource)
 
         span(reorder_handle_content, :class => 'reorder-handle', 'data-reorder-url' => url, 'data-reorder-id' => resource.id)
       end


### PR DESCRIPTION
`activeadmin_reorderable` cannot generate correct action path if resource is nested, ie:

    ActiveAdmin.register Post do
        belongs_to :user

It throws an error:

    undefined method `reorder_admin_post_path' for #<ActiveAdmin::Views::ReorderableTableFor:0x000000011afc8e90>

because actual path will be available by `reorder_admin_user_post_path` (with parent `user`)

To generate correct path, we need to take into account whether our resource is nested.

ActiveAdmin's RouterBuilder has all methods we need and performs all needed checks for us, so we just use it.

Our new method will generate urls like `/admin/users/5/posts/20/reorder` if our resource is nested and urls like `/admin/posts/20/reorder` if it is not nested.