### PR TITLE
Add ability to show flash message when a reorder is saved

### DIFF
--- a/app/assets/javascripts/activeadmin_reorderable.js
+++ b/app/assets/javascripts/activeadmin_reorderable.js
@@ -47,11 +47,36 @@ $.fn.reorderable = function (opts) {
     var top_id = $row.prev().find('.reorder-handle').data("reorderId")
     var bottom_id = $row.next().find('.reorder-handle').data("reorderId")
 
-    $.post(url, {
-      position: index($row),
-      top_id: top_id,
-      bottom_id: bottom_id 
+    $.ajax({
+      type: "POST",
+      url: url,
+      data: {
+        position: index($row),
+        top_id: top_id,
+        bottom_id: bottom_id,
+      },
+      success: () => { onAjaxSuccess(e.target) },
+      error: () => { onAjaxError(e.target) },
     });
+  }
+
+  function onAjaxSuccess(table){
+    if(table.dataset.showFlashMessages !== "true") return;
+
+    var $message = document.createElement("div")
+    $message.innerHTML = "<div class='flash flash_notice'>Successfully reordered item.</div>"
+    var $flashes = document.querySelector(".flashes")
+    $flashes.innerHTML = ""
+    $flashes.append($message)
+  }
+
+  function onAjaxError(table){
+    if(table.dataset.showFlashMessages !== "true") return;
+
+    var $message = document.createElement("div")
+    $message.innerHTML = "<div class='flash flash_error'>Couldn't reorder item.</div>"
+    var $flashes = document.querySelector(".flashes")
+    $flashes.append($message)
   }
 
   return this.each(function () {


### PR DESCRIPTION
Without some sort of UI element acknowledging the change, it's hard for the user to know that the change was saved automatically.

This PR adds some JS code to listen to the `POST /reorder` ajax request and on success or error, display a message within AA's default `flashes` div.

I personally think this is something that could be default behavior, but for now, I've left it as something that has to be enabled for each call to `reorderable_table` like this:

```ruby
reorderable_table_for collection, "data-show-flash-messages": true do
```